### PR TITLE
修改requirements.txt中python-memcached拼写错误

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ supervisor
 Docutils
 Pygments
 mysql-python
-python-memecached
+python-memcached
 django-debug-toolbar


### PR DESCRIPTION
在本地部署环境的时候，发现requirements.txt中的python-memcached拼写问题。 你的代码很专业！
